### PR TITLE
Correction in logout process

### DIFF
--- a/lib/storage/shared_preferences/shared_preferences_storage.dart
+++ b/lib/storage/shared_preferences/shared_preferences_storage.dart
@@ -20,11 +20,11 @@ class SharedPreferencesStorage implements StorageInterface {
     preferences = 
   }
 */
-  @override
+@override
   Future<void> clear() async {
     var storage = await preferences;
-    storage.remove("access_token");
-    storage.remove("refresh_token");
+    storage.remove(accessTokenKey);
+    storage.remove(refreshTokenKey);
   }
 
   @override


### PR DESCRIPTION
The clear() function has been updated to correctly delete the tokens created in the login process as it was deleting incorrect instances inside the storage so it never made a complete logout.